### PR TITLE
add /variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ There are default values for all values in this path, with the exception of `<va
 /<variant>/releases/allplatforms/allbuilds/info
 ```
 
+To view the list of available variants simply use the following [route](https://api.adoptopenjdk.net/variants):
+
+```
+/variants
+```
+
 This means that each of the following paths all return the same result (information about all builds, all platforms, of the 'release' build type):
 
 - `/openjdk8`

--- a/app/routes/v1.js
+++ b/app/routes/v1.js
@@ -1,6 +1,7 @@
 const request = require('request');
 
 var platforms = [];
+var variants = [];
 var lookup = {};
 var i = 0;
 
@@ -62,6 +63,20 @@ module.exports = function(req, res) {
   request('https://adoptopenjdk.net/dist/json/config.json', function(error, response, body) {
     if (!error && response.statusCode == 200) {
       platforms = JSON.parse(body).platforms;
+      variants = JSON.parse(body).variants;
+
+      if (ROUTEvariant == "variants") {
+        var variantArray = []
+        for (var variant in variants) {
+          var variantObj = new Object()
+          variantObj.name = variants[variant].officialName
+          variantObj.variant = variants[variant].searchableName
+          variantArray.push(variantObj);
+        }
+        res.json(variantArray)
+        return variantArray
+      }
+
       setLookup();
 
       // get the JSON file based on the request


### PR DESCRIPTION
This PR adds `/variants` allowing users to view all available variants

closes: https://github.com/AdoptOpenJDK/openjdk-api/issues/45