### PR TITLE
Fix auth'd cooldown time in GitHub file cache (6s vs 1m)

### DIFF
--- a/app/lib/github_file_cache.js
+++ b/app/lib/github_file_cache.js
@@ -66,10 +66,10 @@ module.exports = function () {
 
   function getCooldown() {
     if (auth !== undefined && auth !== null && auth.length > 0) {
-      // 1 min
-      return 6000;
+      // 1 min (in ms)
+      return 60000;
     } else {
-      // 30 min
+      // 30 min (in ms)
       return 1800000;
     }
   }


### PR DESCRIPTION
Currently, if the API app is given GitHub API credentials the cached results will only be valid for 6 seconds (6000ms), which can result in relatively noticeable delays while GitHub is queried.  This PR adds a missing zero, resulting in caching for the expected 1 minute.