### PR TITLE
Version parameter limit, NodeJS 10, and miscellaneous tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: node_js
 os:
   - linux
 node_js:
-  - "6"
+  - "10"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN \
     rm -rf /var/lib/apt/lists/*
 
 # setup nodejs
-RUN curl -sL https://deb.nodesource.com/setup_8.x |  bash -
+RUN curl -sL https://deb.nodesource.com/setup_10.x |  bash -
 RUN apt-get install -y nodejs
 
 # expose ports which are being used in this project

--- a/app/routes/v2.js
+++ b/app/routes/v2.js
@@ -152,7 +152,7 @@ function sanityCheckParams(res, ROUTErequestType, ROUTEbuildtype, ROUTEversion, 
     errorMsg = 'Unknown request type';
   } else if (!['releases', 'nightly'].includes(ROUTEbuildtype)) {
     errorMsg = 'Unknown build type';
-  } else if (!/^openjdk(?:[0-9]+|-amber)$/.test(ROUTEversion)) {
+  } else if (!/^openjdk(?:\d{1,2}|-amber)$/.test(ROUTEversion)) {
     errorMsg = 'Unknown version type';
   } else if (_.isString(ROUTEopenjdkImpl) && !['hotspot', 'openj9'].includes(ROUTEopenjdkImpl.toLowerCase())) {
     errorMsg = 'Unknown openjdk_impl';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1647,7 +1647,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2062,7 +2063,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2118,6 +2120,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
@@ -2161,12 +2164,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
This PR sets a range (0-99) for the `version` request parameter, which could potentially impact cache size.

There are also various minor tweaks to `v2.js` for consistency, readability, etc.  Some of it's personal preference, so no problem if you all prefer something different.