### PR TITLE
Return the 'release_link' property, the actual release URL.

### DIFF
--- a/app/routes/v1.js
+++ b/app/routes/v1.js
@@ -162,6 +162,7 @@ function processJSON(importedJSON, ROUTEplatform, ROUTEbuild, ROUTEbuildtype) {
       if(atLeastOneAsset) {
         var releaseObj = new Object();
         releaseObj.release_name = eachRelease.name;
+        releaseObj.release_link = eachRelease.html_url;
         releaseObj.timestamp = eachRelease.published_at;
         releaseObj.binaries = assetArray;
         exportedJSON.push(releaseObj);

--- a/app/routes/v2.js
+++ b/app/routes/v2.js
@@ -388,6 +388,7 @@ function githubReleaseToAdoptRelease(release) {
 
   return {
     release_name: release.tag_name,
+    release_link: release.html_url,
     timestamp: release.published_at,
     release: !release.prerelease,
     binaries: binaries


### PR DESCRIPTION
This is for AdoptOpenJDK/openjdk-website#286, where invalid release URLs are being generated due to old+new repo stuff.