### PR TITLE
'routes/index.js' tweaks

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -6,11 +6,11 @@ module.exports = function (app) {
 
   // API version 2
   // Examples:
-  //      /info/releases/openjdk8
-  //      /info/nightly/openjdk8
-  //      /info/nightly/openjdk8?openjdk_impl=hotspot&os=windows&arch=x64
-  //      /binary/releases/openjdk8
-  //      /binary/nightly/openjdk8
+  //  /v2/info/releases/openjdk8
+  //  /v2/info/nightly/openjdk8
+  //  /v2/info/nightly/openjdk8?openjdk_impl=hotspot&os=windows&arch=x64
+  //  /v2/binary/releases/openjdk8
+  //  /v2/binary/nightly/openjdk8
   //
   // Optional query parameters:
   //  openjdk_impl ::= "hotspot" | "openj9"

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -5,6 +5,11 @@ const v2 = require('./v2');
 // add future versions here. Also add to the routesVersioning object below.
 
 module.exports = function (app) {
+  app.use((req, res, next) => {
+    app.set('json spaces', req.query.pretty === 'false' ? false : 2);
+    next();
+  });
+
   app.get([
       //these 3 paths dont make sense and are not valid, but if you dont have them then the matching will fall through to the v1 api
       '/v2',
@@ -33,14 +38,6 @@ module.exports = function (app) {
     //
     // curl "http://127.0.0.1:3000/v2/binary/nightly/openjdk8?openjdk_impl=hotspot&os=windows&arch=x64&release=latest&type=jdk"
     // curl "http://127.0.0.1:3000/v2/info/releases/openjdk10?openjdk_impl=hotspot&type=jdk"
-
-    function handleRequest(req, res, next) {
-      app.set('json spaces', 2);
-      if (req.query.pretty === 'false') {
-        app.disable('json spaces')
-      }
-      next()
-    },
     routesVersioning({
       '^2.0.0': v2
     })
@@ -58,13 +55,6 @@ module.exports = function (app) {
       '/:variant/:buildtype/:platform/:build',
       '/:variant/:buildtype/:platform/:build/:datatype',
     ],
-    function (req, res, next) {
-      app.set('json spaces', 2);
-      if (req.query.pretty === 'false') {
-        app.disable('json spaces')
-      }
-      next()
-    },
     routesVersioning({
       '^1.0.0': v1
       // add future versions here, with a comma ( , ) after the previous line. Also add the require(); above.

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,76 +1,31 @@
-const routesVersioning = require('express-routes-versioning')();
-const v1 = require('./v1');
-const v2 = require('./v2');
-
-// add future versions here. Also add to the routesVersioning object below.
-
 module.exports = function (app) {
   app.use((req, res, next) => {
     app.set('json spaces', req.query.pretty === 'false' ? false : 2);
     next();
   });
 
+  // API version 2
+  // Examples:
+  //      /info/releases/openjdk8
+  //      /info/nightly/openjdk8
+  //      /info/nightly/openjdk8?openjdk_impl=hotspot&os=windows&arch=x64
+  //      /binary/releases/openjdk8
+  //      /binary/nightly/openjdk8
+  //
+  // Optional query parameters:
+  //  openjdk_impl ::= "hotspot" | "openj9"
+  //  os ::= "windows" | "linux"
+  //  arch ::= "x64" | "x32" | "ppc64"
+  //  release ::= "latest"| <jdk_version>
+  //  type ::= "jdk" | "jre"
+  //
+  // curl "http://127.0.0.1:3000/v2/binary/nightly/openjdk8?openjdk_impl=hotspot&os=windows&arch=x64&release=latest&type=jdk"
+  // curl "http://127.0.0.1:3000/v2/info/releases/openjdk10?openjdk_impl=hotspot&type=jdk"
+  app.get('/v2/:requestType?/:buildtype?/:version?', require('./v2'));
+
+  // API version 1
   app.get([
-      //these 3 paths dont make sense and are not valid, but if you dont have them then the matching will fall through to the v1 api
-      '/v2',
-      '/v2/:requestType',
-      '/v2/:requestType/:buildtype',
-
-
-
-      '/v2/:requestType/:buildtype/:version'],
-
-    // Examples:
-    //      /info/releases/openjdk8
-    //      /info/nightly/openjdk8
-    //      /info/nightly/openjdk8?openjdk_impl=hotspot&os=windows&arch=x64
-
-    //      /binary/releases/openjdk8
-    //      /binary/nightly/openjdk8
-
-    // optional query parameters:
-    //
-    //  openjdk_impl ::= "hotspot" | "openj9"
-    //  os ::= "windows" | "linux"
-    //  arch ::= "x64" | "x32" | "ppc64"
-    //  release ::= "latest"| <jdk_version>
-    //  type ::= "jdk" | "jre"
-    //
-    // curl "http://127.0.0.1:3000/v2/binary/nightly/openjdk8?openjdk_impl=hotspot&os=windows&arch=x64&release=latest&type=jdk"
-    // curl "http://127.0.0.1:3000/v2/info/releases/openjdk10?openjdk_impl=hotspot&type=jdk"
-    routesVersioning({
-      '^2.0.0': v2
-    })
-  ).get([
-      '/v1/:variant',
-      '/v1/:variant/:buildtype',
-      '/v1/:variant/:buildtype/:platform',
-      '/v1/:variant/:buildtype/:platform/:build',
-      '/v1/:variant/:buildtype/:platform/:build/:datatype',
-
-      //Maintain backwards compatibility for a while
-      '/:variant',
-      '/:variant/:buildtype',
-      '/:variant/:buildtype/:platform',
-      '/:variant/:buildtype/:platform/:build',
-      '/:variant/:buildtype/:platform/:build/:datatype',
-    ],
-    routesVersioning({
-      '^1.0.0': v1
-      // add future versions here, with a comma ( , ) after the previous line. Also add the require(); above.
-    })
-  );
-
-
-  /*
-
-    if future versions add more routes, create a new 'app.get' here with that route, using either
-    the caret ( ^ ) or tilde ( ~ ) symbol (see npm version rules) to only allow usage of certain
-    versions when using that route, e.g:
-
-    app.get(['/newroute'], routesVersioning({
-      '^8.0.0': v8
-    }));
-
-  */
+    '/v1/:variant/:buildtype?/:platform?/:build?/:datatype?',
+    '/:variant/:buildtype?/:platform?/:build?/:datatype?' // Maintain backwards compatibility for a while
+  ], require('./v1'));
 };

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -5,12 +5,6 @@ const v2 = require('./v2');
 // add future versions here. Also add to the routesVersioning object below.
 
 module.exports = function (app) {
-
-  app.get('/favicon.ico', function (req, res) {
-    res.status(204);
-  });
-
-
   app.get([
       //these 3 paths dont make sense and are not valid, but if you dont have them then the matching will fall through to the v1 api
       '/v2',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1339,11 +1339,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "express-routes-versioning": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/express-routes-versioning/-/express-routes-versioning-1.0.1.tgz",
-      "integrity": "sha1-5TaAf9swxOtJduVmh60GHrxqDkI="
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -1647,8 +1642,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1662,23 +1656,21 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -1691,20 +1683,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1745,7 +1734,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -1760,14 +1749,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
@@ -1776,12 +1765,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -1796,7 +1785,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "^2.1.0"
           }
         },
         "ignore-walk": {
@@ -1805,7 +1794,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -1814,15 +1803,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1834,9 +1822,8 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -1849,25 +1836,22 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
@@ -1876,14 +1860,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1900,9 +1883,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -1911,16 +1894,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.7",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -1929,8 +1912,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -1945,8 +1928,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -1955,17 +1938,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1977,9 +1959,8 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -2000,8 +1981,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -2022,10 +2003,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -2042,13 +2023,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -2057,14 +2038,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2100,11 +2080,10 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -2113,16 +2092,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -2137,13 +2115,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {
@@ -2158,20 +2136,18 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "body-parser": "^1.18.3",
     "express": "^4.16.4",
     "express-rate-limit": "^3.2.1",
-    "express-routes-versioning": "^1.0.0",
     "markdown-serve": "^0.5.0",
     "npm": "^6.4.1",
     "pug": "^2.0.3",


### PR DESCRIPTION
* Removes `express-routes-versioning`
  * We're sending v1 to v1 and v2 to v2, with no minor/patch handling within major versions, so this module (introduced May 2017) doesn't seem to be serving any purpose.
* Cleans up routes via optional named parameters
* Removes unnecessary `/favicon.ico` route
  * Handled by `express.static` serving `markdown-layouts/favicon.ico`
* Moves `json spaces` stuff to common middleware