### PR TITLE
Allow _ in 'random suffix' so that _openj9-0.11.0 release is detected

### DIFF
--- a/app/routes/v2.js
+++ b/app/routes/v2.js
@@ -267,7 +267,7 @@ function getNewStyleFileInfo(name) {
 
   // IF YOU ARE MODIFYING THIS THEN THE FILE MATCHING IS PROBABLY WRONG, MAKE SURE openjdk-website-backend, Release.sh IS UPDATED TOO
   //                  1) num          2) jre/jdk          3) arch                4) OS               5) impl                6)heap                   7) timestamp/version                                         8) Random suffix               9) extension
-  let regex = 'OpenJDK(?<num>[0-9]+)U?(?<type>-jre|-jdk)?_(?<arch>[0-9a-zA-Z-]+)_(?<os>[0-9a-zA-Z]+)_(?<impl>[0-9a-zA-Z]+)_?(?<heap>[0-9a-zA-Z]+)?.*_(?<ts_or_version>' + timestampRegex + '|' + versionRegex + ')(?<rand_suffix>[-0-9A-Za-z\\.]+)?\\.(?<extension>tar\\.gz|zip)';
+  let regex = 'OpenJDK(?<num>[0-9]+)U?(?<type>-jre|-jdk)?_(?<arch>[0-9a-zA-Z-]+)_(?<os>[0-9a-zA-Z]+)_(?<impl>[0-9a-zA-Z]+)_?(?<heap>[0-9a-zA-Z]+)?.*_(?<ts_or_version>' + timestampRegex + '|' + versionRegex + ')(?<rand_suffix>[-0-9A-Za-z\\._]+)?\\.(?<extension>tar\\.gz|zip)';
 
   let matched = name.match(new RegExp(regex));
 


### PR DESCRIPTION
Adjustment to https://github.com/AdoptOpenJDK/openjdk-api/pull/101 so that https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/tag/jdk8u192-b12_openj9-0.11.0 shows up