### PR TITLE
Sort releases (i.e. non-nightlies) by name rather than timestamp.

### DIFF
--- a/app/routes/v2.js
+++ b/app/routes/v2.js
@@ -21,7 +21,7 @@ function filterRelease(releases, releaseName) {
 
     return releases
       .sortBy(function (release) {
-        return release.timestamp
+        return release.release ? release.release_name : release.timestamp
       })
       .last()
 
@@ -427,6 +427,6 @@ function githubDataToAdoptApi(githubApiData) {
       return release.binaries.length > 0;
     })
     .sortBy(function (release) {
-      return release.timestamp
+      return release.release ? release.release_name : release.timestamp
     });
 }


### PR DESCRIPTION
Sorting releases by timestamp becomes a problem when an old JDK version gets released after a newer version (e.g. jdk8u191-b12 after jdk8u192-b12).

Looking at past 8-11 release names (and my own testing) sorting by name should have the expected result.  Nightlies are a bit all over the place in their naming so timestamp is the safest way to keep those "latest".

This resolves #124