### PR TITLE
Add regression test that compares current version against the deployed API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .idea/
 cache/
+auth/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,29 @@
 FROM ubuntu
 
+
+
 RUN \
     apt-get update; \
     apt-get install -y \
     build-essential \
+    nano \
     curl; \
     rm -rf /var/lib/apt/lists/*
 
-# setup nodejs
+
 RUN curl -sL https://deb.nodesource.com/setup_10.x |  bash -
-RUN apt-get install -y nodejs
+
+RUN \
+    apt-get update; \
+    apt-get install -y \
+    nodejs;
 
 # expose ports which are being used in this project
 EXPOSE 3001
 EXPOSE 3000
+
+RUN useradd -ms /bin/bash ubuntu
+USER ubuntu
+WORKDIR /home/ubuntu
 
 CMD /bin/bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,36 @@
         "@types/babel-types": "*"
       }
     },
+    "@types/concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/form-data": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+      "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "9.6.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.41.tgz",
+      "integrity": "sha512-sPZWEbFMz6qAy9SLY7jh5cgepmsiwqUUHjvEm8lpU6kug2hmmcyuTnwhoGw/GWpI5Npue4EqvsiQQI0eWjW/ZA==",
+      "dev": true
+    },
+    "@types/qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-mNhVdZHdtKHMMxbqzNK3RzkBcN1cux3AvuCYGTvjEIQT2uheH3eCAyYsbMbh2Bq8nXkeOWs1kyDiF7geWRFQ4Q==",
+      "dev": true
+    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -60,7 +90,7 @@
     },
     "acorn": {
       "version": "3.3.0",
-      "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
       "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
     },
     "acorn-globals": {
@@ -122,7 +152,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -776,7 +806,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
@@ -994,6 +1024,18 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "configstore": {
       "version": "3.1.2",
@@ -1904,7 +1946,7 @@
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
@@ -1987,7 +2029,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
@@ -2621,9 +2663,15 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
+    "get-port": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
+      "dev": true
+    },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -2729,7 +2777,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -2875,7 +2923,7 @@
     },
     "highlight.js": {
       "version": "8.2.0",
-      "resolved": "http://registry.npmjs.org/highlight.js/-/highlight.js-8.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-8.2.0.tgz",
       "integrity": "sha1-MawOpdIPiPVilI5+jrWmLp6MXkM="
     },
     "home-or-tmp": {
@@ -2903,15 +2951,38 @@
         "whatwg-encoding": "^1.0.1"
       }
     },
+    "http-basic": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-7.0.0.tgz",
+      "integrity": "sha1-gvClBr6UJzLsje6+6A50bvVzbbo=",
+      "dev": true,
+      "requires": {
+        "@types/concat-stream": "^1.6.0",
+        "@types/node": "^9.4.1",
+        "caseless": "~0.12.0",
+        "concat-stream": "^1.4.6",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      }
+    },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
         "statuses": ">= 1.4.0 < 2"
+      }
+    },
+    "http-response-object": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.1.tgz",
+      "integrity": "sha512-6L0Fkd6TozA8kFSfh9Widst0wfza3U1Ex2RjJ6zNDK0vR1U1auUR6jY4Nn2Xl7CCy0ikFmxW1XcspVpb9RvwTg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^9.3.0"
       }
     },
     "http-signature": {
@@ -3232,7 +3303,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -4453,6 +4524,15 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -4468,6 +4548,12 @@
       "version": "0.5.1",
       "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsprim": {
@@ -4681,7 +4767,7 @@
     },
     "marked": {
       "version": "0.3.19",
-      "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
       "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
     },
     "math-random": {
@@ -4692,7 +4778,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
@@ -4793,7 +4879,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mixin-deep": {
@@ -4819,7 +4905,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -7855,7 +7941,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -7900,6 +7986,12 @@
         "registry-url": "^3.0.3",
         "semver": "^5.1.0"
       }
+    },
+    "parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104=",
+      "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
@@ -8342,7 +8434,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -8561,7 +8653,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -8676,7 +8768,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -9147,7 +9239,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -9171,6 +9263,26 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
+    },
+    "sync-request": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.0.0.tgz",
+      "integrity": "sha512-jGNIAlCi9iU4X3Dm4oQnNQshDD3h0/1A7r79LyqjbjUnj69sX6mShAXlhRXgImsfVKtTcnra1jfzabdZvp+Lmw==",
+      "dev": true,
+      "requires": {
+        "http-response-object": "^3.0.1",
+        "sync-rpc": "^1.2.1",
+        "then-request": "^6.0.0"
+      }
+    },
+    "sync-rpc": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.4.tgz",
+      "integrity": "sha512-Iug+t1ICVFenUcTnDu8WXFnT+k8IVoLKGh8VA3eXUtl2Rt9SjKX3YEv33OenABqpTPL9QEaHv1+CNn2LK8vMow==",
+      "dev": true,
+      "requires": {
+        "get-port": "^3.1.0"
+      }
     },
     "table": {
       "version": "5.1.1",
@@ -9320,6 +9432,42 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "then-request": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.0.tgz",
+      "integrity": "sha512-xA+7uEMc+jsQIoyySJ93Ad08Kuqnik7u6jLS5hR91Z3smAoCfL3M8/MqMlobAa9gzBfO9pA88A/AntfepkkMJQ==",
+      "dev": true,
+      "requires": {
+        "@types/concat-stream": "^1.6.0",
+        "@types/form-data": "0.0.33",
+        "@types/node": "^8.0.0",
+        "@types/qs": "^6.2.31",
+        "caseless": "~0.12.0",
+        "concat-stream": "^1.6.0",
+        "form-data": "^2.2.0",
+        "http-basic": "^7.0.0",
+        "http-response-object": "^3.0.1",
+        "promise": "^8.0.0",
+        "qs": "^6.4.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.10.39",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.39.tgz",
+          "integrity": "sha512-rE7fktr02J8ybFf6eysife+WF+L4sAHWzw09DgdCebEu+qDwMvv4zl6Bc+825ttGZP73kCKxa3dhJOoGJ8+5mA==",
+          "dev": true
+        },
+        "promise": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.2.tgz",
+          "integrity": "sha512-EIyzM39FpVOMbqgzEHhxdrEhtOSDOtjMZQ0M6iVfCE+kWNgCkAyOdnuCWqfmflylftfadU6FkiMgHZA2kUzwRw==",
+          "dev": true,
+          "requires": {
+            "asap": "~2.0.6"
+          }
+        }
+      }
+    },
     "throat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
@@ -9328,7 +9476,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -9471,6 +9619,12 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.18"
       }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -9952,7 +10106,7 @@
     },
     "yargs": {
       "version": "3.10.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "requires": {
         "camelcase": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "scripts": {
     "start": "nodemon --ignore cache/ server.js",
     "lint": "eslint *.js app/routes/*.js",
-    "test": "jest --coverage && npm run lint"
+    "test": "jest --coverage test/*.test.js && npm run lint",
+    "test:regression": "jest --coverage test/regression/*.test.js"
   },
   "dependencies": {
     "async": "^2.6.1",
@@ -35,6 +36,9 @@
     "eslint-plugin-jest": "^22.1.2",
     "eslint-plugin-jest-async": "^1.0.3",
     "jest": "^23.6.0",
-    "nodemon": "^1.18.9"
+    "nodemon": "^1.18.9",
+    "rimraf": "^2.6.2",
+    "sync-request": "^6.0.0",
+    "json-stable-stringify": "^1.0.1"
   }
 }

--- a/test/regression/v2.test.js
+++ b/test/regression/v2.test.js
@@ -1,0 +1,228 @@
+const _ = require('underscore');
+const Q = require('q');
+const rimraf = require("rimraf");
+const request = require('sync-request');
+const stringify = require('json-stable-stringify');
+
+const GitHubFileCache = require('../../app/lib/github_file_cache');
+const cache = new GitHubFileCache();
+const v2 = require('../../app/routes/v2')(cache);
+
+
+/*
+    If nop changes are being made to the API this can confirm that there are no changes compared to the current
+     public api.
+
+    Can be run with :
+      npm run test:regression | tee test.log 2>&1
+
+    Note this test does make real web hits and may take a long time.
+ */
+
+describe('v2 API regression test', () => {
+
+  beforeAll(() => {
+    rimraf.sync("./cache");
+  });
+
+  const TEST_COUNT_LIMIT = 500;
+
+  function deepOmit(obj, iteratee) {
+    var r = _.omit(obj, iteratee);
+
+    _.each(r, function (val, key) {
+      if (typeof (val) === "object")
+        r[key] = deepOmit(val, iteratee);
+    });
+
+    return r;
+  }
+
+  function removeDownloadCount(obj) {
+    return deepOmit(obj, 'download_count')
+  }
+
+  const currentApiUrl = "https://api.adoptopenjdk.net/v2";
+  console.log("num requests: " + getAllPermutations().length);
+
+  describe('Returns the same as existing', () => {
+    _.chain(getAllPermutations())
+      .first(TEST_COUNT_LIMIT)
+      .each(perm => {
+        it(`Request: ${JSON.stringify(perm)}`, async () => {
+          jest.setTimeout(10000);
+          await doCompare(
+            perm.requestType,
+            perm.releaseType,
+            perm.jdkVersion,
+            perm.openjdk_impl,
+            perm.os,
+            perm.arch,
+            perm.release,
+            perm.type,
+            perm.heap_size,
+          );
+        })
+      });
+
+  });
+
+  function stabiliseObject(obj) {
+    // run through json-stable-stringify to stabilise
+    return removeDownloadCount(JSON.parse(stringify(JSON.parse(obj))));
+  }
+
+  async function doCompare(requestType, buildtype, version, openjdk_impl, os, arch, release, type, heap_size) {
+
+    const url = formUrl(requestType, buildtype, version, openjdk_impl, os, arch, release, type, heap_size);
+    const response = request('GET', url);
+
+    const result = await performRequest(requestType, buildtype, version, openjdk_impl, os, arch, release, type, heap_size);
+
+    const code = result[0].value;
+    const msg = result[1].value;
+
+    if (response.statusCode === 200 || response.statusCode === 302) {
+      expect(response.statusCode).toEqual(code);
+
+      const expectedBody = stabiliseObject(response.getBody('utf8'));
+      const actualBody = stabiliseObject(msg);
+
+      expect(expectedBody).toEqual(actualBody);
+    } else {
+      expect(response.statusCode).toEqual(code);
+    }
+  }
+
+
+  function formUrl(requestType, buildtype, version, openjdk_impl, os, arch, release, type, heap_size) {
+
+    var url = `${currentApiUrl}/${requestType}/${buildtype}/${version}?`;
+
+    if (openjdk_impl !== undefined) url += `openjdk_impl=${openjdk_impl}&`;
+    if (os !== undefined) url += `os=${os}&`;
+    if (arch !== undefined) url += `arch=${arch}&`;
+    if (release !== undefined) url += `release=${release}&`;
+    if (type !== undefined) url += `type=${type}&`;
+    if (heap_size !== undefined) url += `heap_size=${heap_size}&`;
+
+    return url;
+  }
+
+
+  function getAllPermutations() {
+    /*
+      Careful of combinatorial explosion here
+
+       this is a full list but makes 1020 hits:
+
+        const requestType = ["info", 'binary', 'latestAssets'];
+        const jdkVersions = ["openjdk8", "openjdk9", "openjdk10", "openjdk11"];
+        const releaseTypes = ["nightly", "releases"];
+
+
+        const impls = [undefined, 'hotspot', 'openj9'];
+        const oss = [undefined, 'windows', 'linux', 'mac'];
+        const archs = [undefined, 'x64', 'x32'];
+        const types = [undefined, 'jdk', 'jre'];
+        const sizes = [undefined, 'large', 'normal'];
+      */
+
+    const requestType = ["info", 'binary', 'latestAssets'];
+    const jdkVersions = ["openjdk8", "openjdk9", "openjdk10", "openjdk11"];
+    const releaseTypes = ["nightly", "releases"];
+
+
+    const impls = [undefined, 'hotspot'];
+    const oss = [undefined, 'linux'];
+    const archs = [undefined, 'x64'];
+    const types = [undefined, 'jdk'];
+    const sizes = [undefined, 'normal'];
+
+    const permutations = [];
+    requestType.forEach(requestType => {
+      releaseTypes.forEach(releaseType => {
+        jdkVersions.forEach(jdkVersion => {
+          permutations.push({
+            requestType: requestType,
+            releaseType: releaseType,
+            jdkVersion: jdkVersion,
+            openjdk_impl: undefined,
+            os: undefined,
+            arch: undefined,
+            release: undefined,
+            type: undefined,
+            heap_size: undefined
+          });
+        })
+      })
+    });
+
+    requestType.forEach(requestType => {
+      impls.forEach(impl => {
+        oss.forEach(os => {
+          archs.forEach(arch => {
+            types.forEach(type => {
+              sizes.forEach(size => {
+                permutations.push({
+                  requestType: requestType,
+                  releaseType: "nightly",
+                  jdkVersion: "openjdk8",
+                  openjdk_impl: impl,
+                  os: os,
+                  arch: arch,
+                  release: undefined,
+                  type: type,
+                  heap_size: size
+                });
+              })
+            })
+          })
+        })
+      })
+    });
+    return permutations;
+  }
+
+  function performRequest(requestType, buildtype, version, openjdk_impl, os, arch, release, type, heap_size) {
+    const codePromise = Q.defer();
+    const msgPromise = Q.defer();
+    const res = {
+      status: (code) => {
+        codePromise.resolve(code);
+      },
+      send: (msg) => {
+        msgPromise.resolve(msg);
+      },
+      json: (msg) => {
+        msgPromise.resolve(JSON.stringify(msg));
+      },
+      redirect: (url) => {
+        codePromise.resolve(302);
+        msgPromise.resolve(url);
+      }
+    };
+
+    const request = {
+      params: {
+        requestType: requestType,
+        buildtype: buildtype,
+        version: version,
+      },
+
+      query: {
+        openjdk_impl: openjdk_impl,
+        os: os,
+        arch: arch,
+        release: release,
+        type: type,
+        heap_size: heap_size,
+      }
+    };
+
+    v2(request, res);
+
+    return Q
+      .allSettled([codePromise.promise, msgPromise.promise]);
+  }
+});


### PR DESCRIPTION
Add a long running test that can be run manually to determine if the current version gives different results to the deployed api. Used to confirm #136 did not significantly change the api results.