### PR TITLE
Fix `npm test` file matching on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ auth/
 regression-data/
 nodejs_dc.log
 nodejs_restclient.log
+coverage/

--- a/jest.config.js
+++ b/jest.config.js
@@ -133,10 +133,10 @@ module.exports = {
   // testLocationInResults: false,
 
   // The glob patterns Jest uses to detect test files
-  // testMatch: [
-  //   "**/__tests__/**/*.js?(x)",
-  //   "**/?(*.)+(spec|test).js?(x)"
-  // ],
+  testMatch: [
+    "**/__tests__/**/*.js?(x)",
+    "**/?(*.)+(spec|test).js?(x)"
+  ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   // testPathIgnorePatterns: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -27,9 +27,10 @@ module.exports = {
   // coverageDirectory: null,
 
   // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  coveragePathIgnorePatterns: [
+    "/node_modules/",
+    "/test/mockCache.js",
+  ],
 
   // A list of reporter names that Jest uses when writing coverage reports
   // coverageReporters: [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "node server.js",
     "start-nodemon": "nodemon --ignore cache/ server.js",
     "lint": "eslint *.js app/routes/*.js",
-    "test": "jest --coverage test/*.test.js && npm run lint"
+    "test": "jest --coverage && npm run lint"
   },
   "dependencies": {
     "@octokit/rest": "^16.6.1",


### PR DESCRIPTION
The matching pattern `jest --coverage test/*.test.js` no longer works with `npm test` on Windows (see https://github.com/facebook/jest/pull/6650). The default glob pattern in jest.config.js matches the same files in both environments, so it shouldn't be needed in the `npm test` script.

I also added mockCache.js to `coveragePathIgnorePatterns` so it would stop showing up in coverage reports.

<details>
    <summary>Before (click for logs)</summary><p>

```
$ npm test

> openjdk-api@1.0.0 test C:\Users\<mypath>\openjdk-api
> jest --coverage test/*.test.js && npm run lint

No tests found, exiting with code 1
Run with `--passWithNoTests` to exit with code 0
In C:\Users\<mypath>\openjdk-api
  37 files checked.
  testMatch: **/__tests__/**/*.[jt]s?(x),**/?(*.)+(spec|test).[tj]s?(x) - 2 matches
  testPathIgnorePatterns: \\node_modules\\ - 37 matches
  testRegex:  - 37 matches
Pattern: test\\*.test.js - 0 matches
npm ERR! Test failed.  See above for more details.
```
</p></details>

<details>
    <summary>After (click for logs)</summary><p>

```
$ npm test

> openjdk-api@1.0.0 test C:\Users\<mypath>\openjdk-api
> jest --coverage && npm run lint

PASS test/versions.test.js
PASS test/v2.test.js
  ● Console

    console.log app/lib/github_file_cache.js:17
      Reading auth

-----------------------|----------|----------|----------|----------|-------------------|
File                   |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-----------------------|----------|----------|----------|----------|-------------------|
All files              |    78.41 |    75.16 |    84.69 |    78.16 |                   |
 lib                   |       50 |       40 |    36.84 |       50 |                   |
  github_file_cache.js |       50 |       40 |    36.84 |       50 |... 55,166,167,179 |
 routes                |    85.46 |    81.82 |     96.2 |    85.25 |                   |
  v2.js                |    83.13 |    78.95 |    95.71 |    82.85 |... 42,543,545,546 |
  versions.js          |      100 |      100 |      100 |      100 |                   |
-----------------------|----------|----------|----------|----------|-------------------|

Test Suites: 2 passed, 2 total
Tests:       129 passed, 129 total
Snapshots:   0 total
Time:        3.088s
Ran all test suites.

> openjdk-api@1.0.0 lint C:\Users\<mypath>\openjdk-api
> eslint *.js app/routes/*.js
```
</p></details>