### PR TITLE
Parse and sort minor build patches from version strings

### DIFF
--- a/app/routes/v2.js
+++ b/app/routes/v2.js
@@ -443,6 +443,7 @@ function sortReleases(data) {
     .sortBy(sortByValue('timestamp'))
     .sortBy(sortByValue('release_name'))
     .sortBy(sortByVersionData('opt'))
+    .sortBy(sortByVersionData('buildpatch'))
     .sortBy(sortByVersionData('build'))
     .sortBy(sortByVersionData('pre'))
     .sortBy(sortByVersionData('security'))

--- a/app/routes/versions.js
+++ b/app/routes/versions.js
@@ -46,7 +46,7 @@ module.exports = function () {
   // Technically the standard supports an arbitrary number of numbers, we will support 3 for now
   const vnumRegex = '(?<major>[0-9]+)(\\.(?<minor>[0-9]+))?(\\.(?<security>[0-9]+))?';
   const pre = '(?<pre>[a-zA-Z0-9]+)';
-  const build = '(?<build>[0-9]+)';
+  const build = '(?<build>[0-9]+(\\.(?<buildpatch>[0-9]+))?)';
   const opt = '(?<opt>[-a-zA-Z0-9\\.]+)';
 
   const version223Regexs = [
@@ -88,6 +88,7 @@ module.exports = function () {
         security: or0(matched.groups.security),
         pre: matched.groups.pre,
         build: toInt(matched.groups.build),
+        buildpatch: toInt(matched.groups.buildpatch),
         opt: matched.groups.opt,
         version: matched.groups.version
       }

--- a/test/v2.test.js
+++ b/test/v2.test.js
@@ -389,8 +389,10 @@ describe('v2 API', () => {
           {"release_name": "jdk-11.10.1+2", "timestamp": 3},
           {"release_name": "jdk-11.2.1+10", "timestamp": 4},
           {"release_name": "jdk-11.2.1+2", "timestamp": 5},
+          {"release_name": "jdk-11.0.4+11_openj9-0.15.1", "timestamp": 6},
+          {"release_name": "jdk-11.0.4+11.2_openj9-0.15.1", "timestamp": 7},
         ],
-        ["jdk-11+2", "jdk-11+100", "jdk-11.2.1+2", "jdk-11.2.1+10", "jdk-11.10.1+2"]);
+        ["jdk-11+2", "jdk-11+100", "jdk-11.0.4+11_openj9-0.15.1", "jdk-11.0.4+11.2_openj9-0.15.1", "jdk-11.2.1+2", "jdk-11.2.1+10", "jdk-11.10.1+2"]);
     });
   });
 

--- a/test/v2.test.js
+++ b/test/v2.test.js
@@ -391,8 +391,21 @@ describe('v2 API', () => {
           {"release_name": "jdk-11.2.1+2", "timestamp": 5},
           {"release_name": "jdk-11.0.4+11_openj9-0.15.1", "timestamp": 6},
           {"release_name": "jdk-11.0.4+11.2_openj9-0.15.1", "timestamp": 7},
+          {"release_name": "jdk-11.0.5+20.2", "timestamp": 8},
+          {"release_name": "jdk-11.0.5+20", "timestamp": 9},
         ],
-        ["jdk-11+2", "jdk-11+100", "jdk-11.0.4+11_openj9-0.15.1", "jdk-11.0.4+11.2_openj9-0.15.1", "jdk-11.2.1+2", "jdk-11.2.1+10", "jdk-11.10.1+2"]);
+        [
+          "jdk-11+2",
+          "jdk-11+100",
+          "jdk-11.0.4+11_openj9-0.15.1",
+          "jdk-11.0.4+11.2_openj9-0.15.1",
+          "jdk-11.0.5+20",
+          "jdk-11.0.5+20.2",
+          "jdk-11.2.1+2",
+          "jdk-11.2.1+10",
+          "jdk-11.10.1+2",
+        ]
+      );
     });
   });
 


### PR DESCRIPTION
Fixes #175 

This PR adds a `buildpatch` attribute to the internal version object so that "minor" build versions can be parsed and sorted consistently.