### PR TITLE
Remove redundant/inconsistent sorting

### DIFF
--- a/app/routes/v2.js
+++ b/app/routes/v2.js
@@ -36,13 +36,7 @@ function filterReleaseOnReleaseName(releases, releaseName) {
   if (releaseName === undefined || releases.value().length === 0) {
     return releases;
   } else if (releaseName === 'latest') {
-
-    return releases
-      .sortBy(function(release) {
-        return release.release ? release.release_name : release.timestamp
-      })
-      .last()
-
+    return releases.last()
   } else {
     return releases
       .filter(function(release) {


### PR DESCRIPTION
Fixes #175 (hopefully for real this time 😀)

The release data was being sorted a second time using outdated comparison logic, which caused some of the sorting from the previous steps to be undone.